### PR TITLE
Merge fix

### DIFF
--- a/.github/workflows/merge-to-branch.yml
+++ b/.github/workflows/merge-to-branch.yml
@@ -5,12 +5,14 @@ on:
         description: 'Destination branch to merge to (ours)'
         required: true
         type: string
-
+    secrets: 
+      GH_TOKEN:
+        required: true  
 permissions:
   contents: write
 
 jobs:
-  merge-to-staging:
+  merge-to-branch:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
@@ -18,6 +20,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.sha }}
+          token: ${{ secrets.GH_TOKEN }}
 
       - name: Merge ${{ github.sha }} -> ${{ inputs.to_branch }}
         run: |

--- a/.github/workflows/merge-to-branch.yml
+++ b/.github/workflows/merge-to-branch.yml
@@ -5,9 +5,6 @@ on:
         description: 'Destination branch to merge to (ours)'
         required: true
         type: string
-    secrets: 
-      GH_TOKEN:
-        required: true  
 permissions:
   contents: write
 
@@ -20,7 +17,6 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.sha }}
-          token: ${{ secrets.GH_TOKEN }}
 
       - name: Merge ${{ github.sha }} -> ${{ inputs.to_branch }}
         run: |

--- a/.github/workflows/merge-to-branch.yml
+++ b/.github/workflows/merge-to-branch.yml
@@ -6,7 +6,7 @@ on:
         required: true
         type: string
     secrets:
-      GH_WRITE_REPO_TOKEN:
+      GH_REPO_WRITE_TOKEN:
         required: true
 permissions:
   contents: write
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.sha }}
-          token: ${{ secrets.GH_WRITE_REPO_TOKEN }}
+          token: ${{ secrets.GH_REPO_WRITE_TOKEN }}
 
       - name: Merge ${{ github.sha }} -> ${{ inputs.to_branch }}
         run: |

--- a/.github/workflows/merge-to-branch.yml
+++ b/.github/workflows/merge-to-branch.yml
@@ -5,6 +5,9 @@ on:
         description: 'Destination branch to merge to (ours)'
         required: true
         type: string
+    secrets:
+      GH_WRITE_REPO_TOKEN:
+        required: true
 permissions:
   contents: write
 
@@ -17,6 +20,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.sha }}
+          token: ${{ GH_WRITE_REPO_TOKEN }}
 
       - name: Merge ${{ github.sha }} -> ${{ inputs.to_branch }}
         run: |

--- a/.github/workflows/merge-to-branch.yml
+++ b/.github/workflows/merge-to-branch.yml
@@ -1,17 +1,10 @@
 on:
   workflow_call:
     inputs:
-      from_branch:
-        description: 'Branch containing the changes to merge (theirs)'
-        required: true
-        type: string
       to_branch:
         description: 'Destination branch to merge to (ours)'
         required: true
         type: string
-    secrets: 
-      GH_WRITE_PACKAGES_TOKEN:
-        required: true
 
 permissions:
   contents: write
@@ -20,16 +13,19 @@ jobs:
   merge-to-staging:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - name: Checkout Code
+        uses: actions/checkout@v2
         with:
-          token: ${{ secrets.GH_WRITE_PACKAGES_TOKEN }}
+          fetch-depth: 0
+          ref: ${{ github.sha }}
 
-      - name: Merge ${{ inputs.from_branch }} -> ${{ inputs.to_branch }}
+      - name: Merge ${{ github.sha }} -> ${{ inputs.to_branch }}
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
           git fetch
           git checkout --progress --force -B ${{ inputs.to_branch }} refs/remotes/origin/${{ inputs.to_branch }}
-          git pull
-          git merge -X theirs ${{ inputs.from_branch }} --allow-unrelated-histories
+          git merge ${{ github.sha }}
+          git status
           git push
+          git status

--- a/.github/workflows/merge-to-branch.yml
+++ b/.github/workflows/merge-to-branch.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.sha }}
-          token: ${{ GH_WRITE_REPO_TOKEN }}
+          token: ${{ secrets.GH_WRITE_REPO_TOKEN }}
 
       - name: Merge ${{ github.sha }} -> ${{ inputs.to_branch }}
         run: |


### PR DESCRIPTION
Merge using `sha` of change rather than branch provided. This will be picked up the trigger for the action which is invoked.

This avoids accidently picking up changes commited since the action started.

No need for the secret as the action will use the GITHUB_TOKEN provided by the action which has write access to the repository.

We can just do a simple merge as we want staging and production to track the dev branch